### PR TITLE
Fix KSP channel creation bug

### DIFF
--- a/impl/init.go
+++ b/impl/init.go
@@ -112,7 +112,7 @@ func (r *RecoverableRedisStreamClient) processLBSMessages(ctx context.Context, s
 			// now seed the mutex
 			lbsInfo.Mutex = mutex
 
-			r.streamLocks[message.ID] = lbsInfo
+			r.streamLocks[lbsInfo.DataStreamName] = lbsInfo
 			r.outputChan <- notifs.Make(v, notifs.StreamAdded)
 
 			// now, keep extending the lock in a separate go routine

--- a/impl/relredis.go
+++ b/impl/relredis.go
@@ -69,7 +69,7 @@ func NewRedisStreamClient(redisClient redis.UniversalClient, serviceName string)
 	return &RecoverableRedisStreamClient{
 		redisClient:      redisClient,
 		consumerID:       consumerID,
-		kspChan:          make(<-chan *redis.Message, 500),
+		kspChan:          make(chan *redis.Message, 500),
 		hbInterval:       defaultHBInterval,
 		streamLocks:      make(map[string]*lbsInfo),
 		serviceName:      serviceName,

--- a/test/client_test.go
+++ b/test/client_test.go
@@ -76,7 +76,7 @@ func TestLBS(t *testing.T) {
 	var expectedMsgConsumer2 string
 	var expectedMsgConsumer1 string
 
-	for i := range 2 {
+	for i := 0; i < 2; i++ {
 		log.Println("iteration: ", i)
 		select {
 		case msg, ok := <-opChan1:


### PR DESCRIPTION
## Summary
- fix creating a read-only channel with `make`
- update unit test loop syntax
- fix a bug in LBS stream lock key storage

## Testing
- `go vet ./...`
- `go test ./...` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_6864f69fed34832a9c77c78bc7e6d2f2