### PR TITLE
Fix typo in cleanup comment

### DIFF
--- a/impl/relredis.go
+++ b/impl/relredis.go
@@ -221,7 +221,7 @@ func (r *RecoverableRedisStreamClient) cleanup() error {
 	// cancel LBS context
 	r.lbsCtxCancelFunc()
 
-	// close the ouptut channe
+	// close the output channel
 	if r.outputChanClosed.CompareAndSwap(false, true) {
 		close(r.outputChan)
 	}


### PR DESCRIPTION
## Summary
- fix typo in comment for closing the output channel

## Testing
- `go test ./...` *(fails: cannot connect to Docker)*

------
https://chatgpt.com/codex/tasks/task_e_686628a57098832ab9ab6896a481b06c