### PR TITLE
Fix stream disowned logic

### DIFF
--- a/test/client_test.go
+++ b/test/client_test.go
@@ -412,22 +412,17 @@ func TestMainFlow(t *testing.T) {
 	consumer1CancelFunc()
 	consumer1Crashed = true
 
-	// check disowned streams
+	// check that no StreamDisowned notification is emitted on normal shutdown
 	streamDisowned := false
-	for msg := range opChan1 {
-		switch msg.Type {
-		case notifs.StreamDisowned:
-			require.Equal(t, msg.Payload, "session0")
+	select {
+	case msg := <-opChan1:
+		if msg.Type == notifs.StreamDisowned {
 			streamDisowned = true
-		default:
 		}
-
-		if streamDisowned {
-			break
-		}
+	case <-time.After(time.Second):
 	}
 
-	require.True(t, streamDisowned)
+	require.False(t, streamDisowned)
 	claimSuccess := false
 	i = 0
 	streamsPickedup = 0


### PR DESCRIPTION
## Summary
- only emit StreamDisowned when mutex extension fails
- update tests for new stream disowned logic

## Testing
- `go vet ./...`
- `go test ./...` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_686628ac63ec832abf8eed869c77acea