### PR TITLE
Fix README client example

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ import rsc "github.com/badari31/redis-stream-client-go/impl"
 ```
 
 ```
-client := rsc.NewRedisStreamClient(<go redis client>, <heartbeat_interval>, <service_name>)
+client := rsc.NewRedisStreamClient(<go redis client>, <service_name>)
 ```
 
 Initialize the client and use the LBC and Key space notification channel for tracking which data streams to read and which have expired respectively:


### PR DESCRIPTION
## Summary
- correct parameters in client creation snippet

## Testing
- `go test ./...` *(fails: cannot connect to Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_686628b4a034832aaee4a6bf4c7a575c