### PR TITLE
Use t.Cleanup to stop redis container

### DIFF
--- a/test/client_test.go
+++ b/test/client_test.go
@@ -40,6 +40,13 @@ func setupSuite(t *testing.T) *redis.RedisContainer {
 	require.True(t, redisContainer != nil)
 	require.True(t, redisContainer.IsRunning())
 
+	t.Cleanup(func() {
+		err := redisContainer.Terminate(context.Background())
+		if err != nil {
+			t.Fatalf("failed to terminate redis container: %v", err)
+		}
+	})
+
 	connString, err := redisContainer.ConnectionString(context.Background())
 	require.NoError(t, err)
 	require.NotEmpty(t, connString)


### PR DESCRIPTION
## Summary
- ensure test containers get cleaned up

## Testing
- `go test ./...` *(fails: cannot connect to docker daemon)*

------
https://chatgpt.com/codex/tasks/task_e_686628b9d118832a9328c8620331facb