### PR TITLE
Explicity conform to Cloud Logging structured logging standards

### DIFF
--- a/impl/relredis.go
+++ b/impl/relredis.go
@@ -102,7 +102,7 @@ func NewRedisStreamClient(
 		rs:               rs,
 		lbsIdleTime:      configs.DefaultLBSIdleTime,
 		lbsRecoveryCount: configs.DefaultLBSRecoveryCount,
-		logger:           slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+		logger:           getGoogleCloudLogger(),
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
CloudLogging only recognizes JSON keys in a [specific format](https://cloud.google.com/logging/docs/structured-logging). #51 changed the logger to use JSON logging, but the keys used by slog don't conform to the keys CloudLogging understands. This PR modifies slog keys to conform to CloudLogging StructuredLogging standards.

Also note that this PR explicitly sets the logging level to `DEBUG`; this is currently set to `INFO`. 