### PR TITLE
Continue processing to the next message if grabbing lock fails

### DIFF
--- a/impl/init.go
+++ b/impl/init.go
@@ -163,7 +163,8 @@ func (r *RecoverableRedisStreamClient) processLBSMessages(
 
 			// lock only once
 			if err := mutex.Lock(); err != nil {
-				return err
+				r.logger.Warn("could not lock mutex for stream", "stream", lbsInfo.DataStreamName, "error", err)
+				continue
 			}
 
 			r.streamLocksMutex.Lock()


### PR DESCRIPTION
In the event a pod is unable to grab a lock for a single message from a set of messages, `processLBSMessages` returns immediately, which is a bit too aggressive. This PR proposes that we move to the next message from the list of messages when this happens.