### PR TITLE
security fix: bump go version to 1.24.11

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ on:
     - cron: '0 2 * * *'
 
 env:
-  GO_VERSION: '1.24.9'  # Single version for consistency
+  GO_VERSION: '1.24.11'  # Single version for consistency
   GOLANGCI_LINT_VERSION: 'latest'
 
 jobs:


### PR DESCRIPTION
Addressing https://pkg.go.dev/vuln/GO-2025-4155