### PR TITLE
Update go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/handcoding-labs/redis-stream-client-go
 
-go 1.26.0
+go 1.24.13
 
 require (
 	github.com/redis/go-redis/v9 v9.6.3


### PR DESCRIPTION
Follow-up to https://github.com/handcoding-labs/redis-stream-client-go/pull/82
Closes https://github.com/handcoding-labs/redis-stream-client-go/issues/80

## Description
We were using go 1.24.11, which apparently has known security vulnerabilities in the `crypto/tls` package. The security vulnerability scanner detected that our code could use TLS functions (through `go-redis`, see https://github.com/handcoding-labs/redis-stream-client-go/issues/80#issuecomment-3865039235 for how), and hence was flagging it.
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests pass
- [ ] Manual testing performed

## Checklist
- [x] Code follows style guidelines
- [x] Self-review completed
- [ ] Documentation updated
- [ ] Tests added and passing
