### PR TITLE
docs: update license badge in README from LGPL-2.1 to Apache-2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -528,4 +528,4 @@ go get github.com/handcoding-labs/redis-stream-client-go
 
 ## License
 
-[LGPL-2.1](https://github.com/handcoding-labs/redis-stream-client-go/blob/main/LICENSE)
+[Apache-2.0](https://github.com/handcoding-labs/redis-stream-client-go/blob/main/LICENSE)


### PR DESCRIPTION
Follows the relicense in v0.4.0 (commit b3a1907).